### PR TITLE
Run tests on 1.x and 2.x versions of PHPCS, but allow 2.x version to have failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,19 @@ php:
     - 5.5
     - hhvm
 
+env:
+    - PHPCS_VERSION='~1.5@dev'
+    - PHPCS_VERSION='~2.0@dev'
+
+matrix:
+    allow_failures:
+        - env: PHPCS_VERSION='~2.0@dev'
+    exclude:
+        - php: hhvm
+          env: PHPCS_VERSION='~2.0@dev'
+
 before_script:
-    - composer require satooshi/php-coveralls:dev-master --dev --prefer-source
+    - composer require satooshi/php-coveralls:dev-master squizlabs/php_codesniffer:$PHPCS_VERSION --dev --prefer-source
 
 script:
     - mkdir -p build/logs


### PR DESCRIPTION
Closes #27
