### PR TITLE
Change way how rules from General standard are included

### DIFF
--- a/CodingStandard/ruleset.xml
+++ b/CodingStandard/ruleset.xml
@@ -6,46 +6,73 @@
         <arg name="tab-width" value="4" />
     -->
 
-	<rule ref="Generic">
-		<!-- TODO: find out why we're excluding following sniffs -->
-		<exclude name="Generic.Formatting.MultipleStatementAlignment"/>
-		<exclude name="Generic.Formatting.SpaceAfterCast"/>
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
-		<exclude name="Generic.NamingConventions.ConstructorName"/>
-		<exclude name="Generic.NamingConventions.CamelCapsFunctionName"/>
-		<exclude name="Generic.NamingConventions.UpperCaseConstantName"/>
-		<exclude name="Generic.PHP.UpperCaseConstant"/>
-		<exclude name="Generic.PHP.ClosingPHPTag"/>
-		<exclude name="Generic.VersionControl.SubversionProperties"/>
-		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
-		<exclude name="Generic.Files.EndFileNoNewline"/>
-		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter"/>
-		<exclude name="Generic.Commenting.Fixme"/>
-		<exclude name="Generic.Commenting.Todo"/>
-		<exclude name="Generic.Files.LowercasedFilename"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <!--PMD does this: <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
+    <!--PMD does this: <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
 
-		<!-- exclude because of multifile sniff, that eats a lot of memory, better to create a separate ruleset -->
-		<exclude name="Generic.Classes.DuplicateClassName"/>
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
-		<!-- let "PHP Mess Detector" deal with that -->
-		<exclude name="Generic.Metrics.CyclomaticComplexity"/>
-	</rule>
+    <rule ref="Generic.Files.ByteOrderMark"/>
+    <rule ref="Generic.Files.EndFileNewline"/>
+    <rule ref="Generic.Files.InlineHTML"/>
+    <rule ref="Generic.Files.LineEndings"/>
 
-	<rule ref="Generic.WhiteSpace.ScopeIndent">
-		<properties>
-			<property name="indent" value="1"/>
-		</properties>
-	</rule>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="140"/>
+        </properties>
+        <exclude-pattern>**/*_config.php</exclude-pattern>
+        <exclude-pattern>**\*_config.php</exclude-pattern>
+    </rule>
 
-	<rule ref="Generic.Files.LineLength">
-		<properties>
-			<property name="lineLimit" value="120"/>
-			<property name="absoluteLineLimit" value="140"/>
-		</properties>
-		<exclude-pattern>**/*_config.php</exclude-pattern>
-		<exclude-pattern>**\*_config.php</exclude-pattern>
-	</rule>
+    <rule ref="Generic.Files.OneClassPerFile">
+        <exclude-pattern>constants.php</exclude-pattern>
+        <exclude-pattern>*Test.php</exclude-pattern>
+    </rule>
 
+    <rule ref="Generic.Files.OneInterfacePerFile">
+        <exclude-pattern>*Test.php</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+    <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
+
+    <rule ref="Generic.Functions.CallTimePassByReference"/>
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
+
+    <!--PMD does this: <rule ref="Generic.Metrics.CyclomaticComplexity"/>-->
+
+    <rule ref="Generic.Metrics.NestingLevel"/>
+
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
+
+    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
+    <rule ref="Generic.PHP.NoSilencedErrors"/>
+    <rule ref="Generic.PHP.SAPIUsage"/>
+
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="1"/>
+        </properties>
+    </rule>
 
 	<rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 
@@ -71,15 +98,6 @@
 
 	<rule ref="Squiz.Classes.LowercaseClassKeywords"/>
 	<rule ref="Squiz.Classes.SelfMemberReference"/>
-
-    <rule ref="Generic.Files.OneClassPerFile">
-        <exclude-pattern>constants.php</exclude-pattern>
-        <exclude-pattern>*Test.php</exclude-pattern>
-    </rule>
-
-    <rule ref="Generic.Files.OneInterfacePerFile">
-        <exclude-pattern>*Test.php</exclude-pattern>
-    </rule>
 
     <rule ref="CodingStandard.Commenting.FunctionComment">
         <exclude-pattern>*Test.php</exclude-pattern>
@@ -174,7 +192,6 @@
 	enforces "===" usage (like in Symfony), but too aggressive for now
 	<rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
 	-->
-
 
 	<rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
 	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>


### PR DESCRIPTION
Include only needed rules from General standard instead of including all but specified.

Closes #28
