### PR TITLE
Improve GitHub Actions workflow for Composer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -38,10 +43,14 @@ jobs:
           php-version: "${{ matrix.php }}"
           tools: composer
 
-      - name: Install dependencies
+      - name: Prepare dependencies
         run: |
           composer require squizlabs/php_codesniffer:${{ matrix.phpcs_version }} --dev --no-update
-          composer update --prefer-dist --no-interaction
+
+      - name: Install dependencies
+        uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Improve GitHub Actions workflow with this:

1. use dedicated GitHub Actions for Composer dependency install
2. auto-cancel concurrent jobs if the subsequent commit is detected in a branch, where build hasn't finished yet