### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The PHP_CodeSniffer coding standard I'm using on all of my projects.
 
-Standard itself and it's test suite complies [PHPCS standard](https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards/PHPCS).
+Standard itself and it's test suite complies [PHPCS standard](https://github.com/PHPCSStandards/PHP_CodeSniffer/tree/2.9/CodeSniffer/Standards/PHPCS).
 
 # Usage
 Only PHP_CodeSniffer 3.x and later versions are supported. For PHP_CodeSniffer 1.x and 2.x use "1.0" branch.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932