### PR TITLE
Fix ControlStructureSpacing sniff requiring blank line around "finally"

### DIFF
--- a/CodingStandard/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/CodingStandard/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -78,6 +78,7 @@ class ControlStructureSpacingSniff implements Sniff
                 T_ELSEIF,
                 T_TRY,
                 T_CATCH,
+                T_FINALLY,
                );
     }//end register()
 
@@ -318,6 +319,7 @@ class ControlStructureSpacingSniff implements Sniff
             || $this->insideSwitchCase($phpcsFile, $leadingContent) === true
             || ($this->elseOrElseIf($phpcsFile, $stackPtr) === true && $this->ifOrElseIf($phpcsFile, $leadingContent) === true)
             || ($this->isCatch($phpcsFile, $stackPtr) === true && $this->isTryOrCatch($phpcsFile, $leadingContent) === true)
+            || ($this->isFinally($phpcsFile, $stackPtr) === true && $this->isTryOrCatch($phpcsFile, $leadingContent) === true)
         ) {
             if ($this->isFunction($phpcsFile, $leadingContent) === true) {
                 // The previous content is the opening brace of a function
@@ -503,6 +505,7 @@ class ControlStructureSpacingSniff implements Sniff
             // Code on the next line after control structure scope closer.
             if ($this->elseOrElseIf($phpcsFile, $trailingContent) === true
                 || $this->isCatch($phpcsFile, $trailingContent) === true
+                || $this->isFinally($phpcsFile, $trailingContent) === true
             ) {
                 return;
             }
@@ -737,6 +740,21 @@ class ControlStructureSpacingSniff implements Sniff
     {
         return $this->isScopeCondition($phpcsFile, $stackPtr, T_CATCH);
     }//end isCatch()
+
+
+    /**
+     * Detects, that it is a closing brace of FINALLY.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
+     *
+     * @return bool
+     */
+    protected function isFinally(File $phpcsFile, $stackPtr)
+    {
+        return $this->isScopeCondition($phpcsFile, $stackPtr, T_FINALLY);
+    }//end isFinally()
 
 
     /**

--- a/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
+++ b/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc
@@ -1691,4 +1691,44 @@ catch ( Exception1 $e ) {
     $c = 'd';
 }
 
+// TRY/FINALLY (no blank line required before/after "finally").
+try {
+    $a = 'b';
+}
+finally {
+    $c = 'd';
+}
+
+// TRY/CATCH/FINALLY (no blank line required before/after "finally").
+try {
+    $a = 'b';
+}
+catch ( Exception $e ) {
+    $c = 'd';
+}
+finally {
+    $c = 'd';
+}
+
+// TRY/FINALLY (blank line before "finally" is not allowed).
+try {
+    $a = 'b';
+}
+
+finally {
+    $c = 'd';
+}
+
+// TRY/CATCH/FINALLY (blank line before "finally" is not allowed).
+try {
+    $a = 'b';
+}
+catch ( Exception $e ) {
+    $c = 'd';
+}
+
+finally {
+    $c = 'd';
+}
+
 ?>

--- a/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
+++ b/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.1.inc.fixed
@@ -1665,4 +1665,42 @@ catch ( Exception1 $e ) {
     $c = 'd';
 }
 
+// TRY/FINALLY (no blank line required before/after "finally").
+try {
+    $a = 'b';
+}
+finally {
+    $c = 'd';
+}
+
+// TRY/CATCH/FINALLY (no blank line required before/after "finally").
+try {
+    $a = 'b';
+}
+catch ( Exception $e ) {
+    $c = 'd';
+}
+finally {
+    $c = 'd';
+}
+
+// TRY/FINALLY (blank line before "finally" is not allowed).
+try {
+    $a = 'b';
+}
+finally {
+    $c = 'd';
+}
+
+// TRY/CATCH/FINALLY (blank line before "finally" is not allowed).
+try {
+    $a = 'b';
+}
+catch ( Exception $e ) {
+    $c = 'd';
+}
+finally {
+    $c = 'd';
+}
+
 ?>

--- a/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -297,6 +297,10 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 
                 // Sequential catch statements not indented right.
                 1690 => 1,
+
+                // Blank line before "finally" is not allowed.
+                1718 => 1,
+                1730 => 1,
                );
         } elseif ($testFile === 'ControlStructureSpacingUnitTest.2.inc') {
             return array(


### PR DESCRIPTION
## Summary

- Fixes #113 — `CodingStandard.WhiteSpace.ControlStructureSpacing` wrongly required (and auto-inserted) a blank line before `finally`, for both `try/finally` and `try/catch/finally`.
- Root cause: this sniff was forked from `Squiz.WhiteSpace.ControlStructureSpacing` in 2014, before upstream added `finally` handling in 2018 (commit `eefb31c68`, fixing the identical `NoLineAfterClose` bug). The fork never picked up that later fix.
- Mirrors the existing `T_CATCH` handling: registers `T_FINALLY`, adds an `isFinally()` helper, and exempts `finally` in both the leading-content (`checkLeadingContent()`) and trailing-content (`checkTrailingContent()`) adjacency checks.

## Test plan

- [x] Added `try/finally` and `try/catch/finally` fixtures to `ControlStructureSpacingUnitTest.1.inc` — two valid (no error) and two invalid (blank line before `finally`, flagged and auto-fixed), regenerated `.inc.fixed`.
- [x] `vendor/bin/phpunit CodingStandard/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php` passes.
- [x] Full suite (`vendor/bin/phpunit`) passes.