### PR TITLE
CI: fix dead scrutinizer-ci.com/ocular.phar URL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Upload Coverage to Scrutinizer CI (PHP < 8.0)
         if: "${{ matrix.php < '8.0' }}"
         run: |
-          wget https://scrutinizer-ci.com/ocular.phar
+          wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
           php ocular.phar code-coverage:upload --repository=g/aik099/CodingStandard --format=php-clover coverage.clover
 
       - name: Upload Coverage to Scrutinizer CI (PHP >= 8.0)


### PR DESCRIPTION
## Problem

Every CI job currently fails, on every branch/PR, regardless of the actual code change. The "Upload Coverage to Scrutinizer CI (PHP < 8.0)" step runs:

```bash
wget https://scrutinizer-ci.com/ocular.phar
```

which now returns `403 Forbidden` — this endpoint appears to be dead. `wget` exits non-zero and fails the whole job, even though `vendor/bin/phpunit` itself passes cleanly right before it (visible in the logs of every currently-failing job, e.g. [PR #114](https://github.com/aik099/CodingStandard/pull/114)).

Only the `PHP < 8.0` step is affected — the `PHP >= 8.0` step installs `scrutinizer/ocular` via Composer instead and never hits that URL.

## Fix

Point `wget` at the GitHub Releases copy of `ocular.phar` instead:

```diff
-  wget https://scrutinizer-ci.com/ocular.phar
+  wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
```

Verified the URL resolves and serves the file (`200 OK`). Same fix already applied in a sibling repo, `console-helpers/svn-buddy` (commit `7a34548`, "Use \"ocular.phar\" from GitHub CDN").

Closes #112