### PR TITLE
CI: fix Scrutinizer coverage upload tagged to wrong commit revision

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,10 +74,10 @@ jobs:
         if: "${{ matrix.php < '8.0' }}"
         run: |
           wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
-          php ocular.phar code-coverage:upload --repository=g/aik099/CodingStandard --format=php-clover coverage.clover
+          php ocular.phar code-coverage:upload --repository=g/aik099/CodingStandard --revision="${{ github.event.pull_request.head.sha || github.sha }}" --format=php-clover coverage.clover
 
       - name: Upload Coverage to Scrutinizer CI (PHP >= 8.0)
         if: "${{ matrix.php >= '8.0' }}"
         run: |
            composer require scrutinizer/ocular
-           vendor/bin/ocular code-coverage:upload --repository=g/aik099/CodingStandard --format=php-clover coverage.clover
+           vendor/bin/ocular code-coverage:upload --repository=g/aik099/CodingStandard --revision="${{ github.event.pull_request.head.sha || github.sha }}" --format=php-clover coverage.clover


### PR DESCRIPTION
## Problem

After #115 fixed the dead `ocular.phar` download URL, coverage uploads to Scrutinizer succeed (e.g. `Uploading code coverage for repository "g/aik099/CodingStandard" and revision "997bb8dd..."... Done` in [#114](https://github.com/aik099/CodingStandard/pull/114)'s logs), but the "Scrutinizer" GitHub status check still errors out on PRs.

Root cause: `ocular.phar code-coverage:upload` defaults `--revision` to `git rev-parse HEAD`. On a `pull_request`-triggered workflow run, `actions/checkout` checks out GitHub's ephemeral **merge commit** (combining base + head), not the PR branch's actual head commit — so the uploaded coverage gets tagged to that merge commit's SHA (`997bb8dd...` in the example above), which is a different SHA on every run and not the commit Scrutinizer's own inspection is tracking (the actual PR head, e.g. `2569dd9c...`). Scrutinizer's inspection never finds coverage for the commit it's watching and the check errors out.

## Fix

Pass `--revision` explicitly to both `ocular.phar`/`ocular` invocations, preferring the real PR head SHA when available:

```
--revision="${{ github.event.pull_request.head.sha || github.sha }}"
```

`github.event.pull_request.head.sha` is only set on `pull_request` events (where the mismatch happens); it falls back to `github.sha` for plain `push` runs, where `git rev-parse HEAD` already matched anyway.