### PR TITLE
Remove Scrutinizer coverage upload steps from CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,15 +69,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload Coverage to Scrutinizer CI (PHP < 8.0)
-        if: "${{ matrix.php < '8.0' }}"
-        run: |
-          wget https://github.com/scrutinizer-ci/ocular/releases/download/1.6.0/ocular.phar
-          php ocular.phar code-coverage:upload --repository=g/aik099/CodingStandard --format=php-clover coverage.clover
-
-      - name: Upload Coverage to Scrutinizer CI (PHP >= 8.0)
-        if: "${{ matrix.php >= '8.0' }}"
-        run: |
-           composer require scrutinizer/ocular
-           vendor/bin/ocular code-coverage:upload --repository=g/aik099/CodingStandard --format=php-clover coverage.clover


### PR DESCRIPTION
## Summary
- Scrutinizer's build was permanently failing at its "Waiting for External Code Coverage" step (analysis errors out, timer stops, red status) regardless of PR content — root cause traced to the `external_code_coverage` tool being enabled in the Scrutinizer dashboard config.
- Coverage requirement is being disabled on the Scrutinizer dashboard side, so the `ocular.phar` upload steps in this workflow are no longer needed.
- CodeCov already covers coverage reporting in the same workflow (`Upload Coverage to CodeCov` step).

## Test plan
- [x] No functional test changes; verified the diff only removes the two Scrutinizer upload steps and workflow YAML is still well-formed.
- [ ] Confirm the "Scrutinizer" GitHub status check turns green after this merges and the dashboard coverage setting is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)